### PR TITLE
Upgrade to .NET 9

### DIFF
--- a/src/Luga/Luga.csproj
+++ b/src/Luga/Luga.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <Authors>r3core</Authors>
@@ -11,7 +11,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Betalgo.OpenAI.GPT3" Version="6.8.3" />
+      <PackageReference Include="Betalgo.OpenAI.GPT3" Version="6.8.4" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- update Luga.csproj to target .NET 9
- bump Betalgo.OpenAI.GPT3 to latest version 6.8.4

## Testing
- `dotnet restore Luga.sln`
- `dotnet build Luga.sln`


------
https://chatgpt.com/codex/tasks/task_e_683fb90856f483219e5d778b234f2963